### PR TITLE
J2 extensions

### DIFF
--- a/sceptre/cli/__init__.py
+++ b/sceptre/cli/__init__.py
@@ -59,7 +59,7 @@ def cli(
         var,
         var_file,
         ignore_dependencies,
-        j2_extensions,
+        j2_extensions
 ):
     """
     Sceptre is a tool to manage your cloud native infrastructure deployments.

--- a/sceptre/cli/__init__.py
+++ b/sceptre/cli/__init__.py
@@ -45,10 +45,20 @@ from sceptre.cli.helpers import setup_logging, catch_exceptions
     help="A YAML file of variables to template into config files.")
 @click.option(
     "--ignore-dependencies", is_flag=True, help="Ignore dependencies when executing command.")
+@click.option(
+    "--j2_extensions", "j2_extensions",  multiple=True, help="jinja2 extensions to load.")
 @click.pass_context
 @catch_exceptions
 def cli(
-        ctx, debug, directory, output, no_colour, var, var_file, ignore_dependencies
+        ctx,
+        debug,
+        directory,
+        output,
+        no_colour,
+        var,
+        var_file,
+        ignore_dependencies,
+        j2_extensions,
 ):
     """
     Sceptre is a tool to manage your cloud native infrastructure deployments.
@@ -63,7 +73,8 @@ def cli(
         "output_format": output,
         "no_colour": no_colour,
         "ignore_dependencies": ignore_dependencies,
-        "project_path": directory if directory else os.getcwd()
+        "project_path": directory if directory else os.getcwd(),
+        "j2_extensions": j2_extensions
     }
     if var_file:
         for fh in var_file:

--- a/sceptre/cli/__init__.py
+++ b/sceptre/cli/__init__.py
@@ -46,7 +46,8 @@ from sceptre.cli.helpers import setup_logging, catch_exceptions
 @click.option(
     "--ignore-dependencies", is_flag=True, help="Ignore dependencies when executing command.")
 @click.option(
-    "--j2_extensions", "j2_extensions",  multiple=True, help="jinja2 extensions to load.")
+    "--j2_extension", "j2_extensions",  multiple=True,
+    help="Import path of Jinja2 extension to load.")
 @click.pass_context
 @catch_exceptions
 def cli(

--- a/sceptre/cli/create.py
+++ b/sceptre/cli/create.py
@@ -32,7 +32,8 @@ def create_command(ctx, path, change_set_name, yes):
         project_path=ctx.obj.get("project_path"),
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),
-        ignore_dependencies=ctx.obj.get("ignore_dependencies")
+        ignore_dependencies=ctx.obj.get("ignore_dependencies"),
+        j2_extensions=ctx.obj.get("j2_extensions")
     )
 
     action = "create"

--- a/sceptre/cli/delete.py
+++ b/sceptre/cli/delete.py
@@ -35,7 +35,8 @@ def delete_command(ctx, path, change_set_name, yes):
         project_path=ctx.obj.get("project_path"),
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),
-        ignore_dependencies=ctx.obj.get("ignore_dependencies")
+        ignore_dependencies=ctx.obj.get("ignore_dependencies"),
+        j2_extensions=ctx.obj.get("j2_extensions")
     )
 
     plan = SceptrePlan(context)

--- a/sceptre/cli/describe.py
+++ b/sceptre/cli/describe.py
@@ -45,7 +45,8 @@ def describe_change_set(ctx, path, change_set_name, verbose):
         options=ctx.obj.get("options"),
         output_format=ctx.obj.get("output_format"),
         no_colour=ctx.obj.get("no_colour"),
-        ignore_dependencies=ctx.obj.get("ignore_dependencies")
+        ignore_dependencies=ctx.obj.get("ignore_dependencies"),
+        j2_extensions=ctx.obj.get("j2_extensions")
     )
 
     plan = SceptrePlan(context)
@@ -77,7 +78,8 @@ def describe_policy(ctx, path):
         options=ctx.obj.get("options"),
         output_format=ctx.obj.get("output_format"),
         no_colour=ctx.obj.get("no_colour"),
-        ignore_dependencies=ctx.obj.get("ignore_dependencies")
+        ignore_dependencies=ctx.obj.get("ignore_dependencies"),
+        j2_extensions=ctx.obj.get("j2_extensions")
     )
 
     plan = SceptrePlan(context)

--- a/sceptre/cli/execute.py
+++ b/sceptre/cli/execute.py
@@ -30,7 +30,8 @@ def execute_command(ctx, path, change_set_name, yes):
         project_path=ctx.obj.get("project_path"),
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),
-        ignore_dependencies=ctx.obj.get("ignore_dependencies")
+        ignore_dependencies=ctx.obj.get("ignore_dependencies"),
+        j2_extensions=ctx.obj.get("j2_extensions")
     )
 
     plan = SceptrePlan(context)

--- a/sceptre/cli/launch.py
+++ b/sceptre/cli/launch.py
@@ -29,7 +29,8 @@ def launch_command(ctx, path, yes):
         project_path=ctx.obj.get("project_path"),
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),
-        ignore_dependencies=ctx.obj.get("ignore_dependencies")
+        ignore_dependencies=ctx.obj.get("ignore_dependencies"),
+        j2_extensions=ctx.obj.get("j2_extensions")
     )
 
     plan = SceptrePlan(context)

--- a/sceptre/cli/list.py
+++ b/sceptre/cli/list.py
@@ -35,7 +35,8 @@ def list_resources(ctx, path):
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),
         output_format=ctx.obj.get("output_format"),
-        ignore_dependencies=ctx.obj.get("ignore_dependencies")
+        ignore_dependencies=ctx.obj.get("ignore_dependencies"),
+        j2_extensions=ctx.obj.get("j2_extensions")
     )
     plan = SceptrePlan(context)
 
@@ -71,7 +72,8 @@ def list_outputs(ctx, path, export):
         user_variables=ctx.obj.get("user_variables", {}),
         options=ctx.obj.get("options", {}),
         output_format=ctx.obj.get("output_format"),
-        ignore_dependencies=ctx.obj.get("ignore_dependencies")
+        ignore_dependencies=ctx.obj.get("ignore_dependencies"),
+        j2_extensions=ctx.obj.get("j2_extensions")
     )
 
     plan = SceptrePlan(context)
@@ -110,7 +112,8 @@ def list_change_sets(ctx, path):
         user_variables=ctx.obj.get("user_variables"),
         output_format=ctx.obj.get("output_format"),
         options=ctx.obj.get("options"),
-        ignore_dependencies=ctx.obj.get("ignore_dependencies")
+        ignore_dependencies=ctx.obj.get("ignore_dependencies"),
+        j2_extensions=ctx.obj.get("j2_extensions")
     )
 
     plan = SceptrePlan(context)

--- a/sceptre/cli/policy.py
+++ b/sceptre/cli/policy.py
@@ -31,7 +31,8 @@ def set_policy_command(ctx, path, policy_file, built_in):
         project_path=ctx.obj.get("project_path"),
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),
-        ignore_dependencies=ctx.obj.get("ignore_dependencies")
+        ignore_dependencies=ctx.obj.get("ignore_dependencies"),
+        j2_extensions=ctx.obj.get("j2_extensions")
     )
     plan = SceptrePlan(context)
 

--- a/sceptre/cli/status.py
+++ b/sceptre/cli/status.py
@@ -28,7 +28,8 @@ def status_command(ctx, path):
         options=ctx.obj.get("options"),
         no_colour=ctx.obj.get("no_colour"),
         output_format=ctx.obj.get("output_format"),
-        ignore_dependencies=ctx.obj.get("ignore_dependencies")
+        ignore_dependencies=ctx.obj.get("ignore_dependencies"),
+        j2_extensions=ctx.obj.get("j2_extensions")
     )
 
     plan = SceptrePlan(context)

--- a/sceptre/cli/template.py
+++ b/sceptre/cli/template.py
@@ -27,7 +27,8 @@ def validate_command(ctx, path):
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),
         output_format=ctx.obj.get("output_format"),
-        ignore_dependencies=ctx.obj.get("ignore_dependencies")
+        ignore_dependencies=ctx.obj.get("ignore_dependencies"),
+        j2_extensions=ctx.obj.get("j2_extensions")
     )
 
     plan = SceptrePlan(context)
@@ -58,7 +59,8 @@ def generate_command(ctx, path):
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),
         output_format=ctx.obj.get("output_format"),
-        ignore_dependencies=ctx.obj.get("ignore_dependencies")
+        ignore_dependencies=ctx.obj.get("ignore_dependencies"),
+        j2_extensions=ctx.obj.get("j2_extensions")
     )
 
     plan = SceptrePlan(context)
@@ -87,7 +89,8 @@ def estimate_cost_command(ctx, path):
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),
         output_format=ctx.obj.get("output_format"),
-        ignore_dependencies=ctx.obj.get("ignore_dependencies")
+        ignore_dependencies=ctx.obj.get("ignore_dependencies"),
+        j2_extensions=ctx.obj.get("j2_extensions")
     )
 
     plan = SceptrePlan(context)

--- a/sceptre/cli/update.py
+++ b/sceptre/cli/update.py
@@ -46,7 +46,8 @@ def update_command(ctx, path, change_set, verbose, yes):
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),
         output_format=ctx.obj.get("output_format"),
-        ignore_dependencies=ctx.obj.get("ignore_dependencies")
+        ignore_dependencies=ctx.obj.get("ignore_dependencies"),
+        j2_extensions=ctx.obj.get("j2_extensions")
     )
 
     plan = SceptrePlan(context)

--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -381,7 +381,8 @@ class ConfigReader(object):
                     default=True,
                 ),
                 loader=FileSystemLoader(abs_directory_path),
-                undefined=StrictUndefined
+                undefined=StrictUndefined,
+                extensions=self.context.j2_extensions,
             )
             template = jinja_env.get_template(basename)
             self.templating_vars.update(stack_group_config)

--- a/sceptre/context.py
+++ b/sceptre/context.py
@@ -40,11 +40,14 @@ class SceptreContext(object):
     :param no_colour: Specify whether colouring should be used in the CLI\
             output
     :type no_colour: bool
+
+    :param j2_extensions: The j2_extensions specified in the CLI command
+    :type j2_extensions: tuple
     """
 
     def __init__(self, project_path, command_path,
                  user_variables=None, options=None, output_format=None,
-                 no_colour=False, ignore_dependencies=False):
+                 no_colour=False, ignore_dependencies=False, j2_extensions=None):
         # project_path: absolute path to the base sceptre project folder
         # e.g. absolute_path/to/sceptre_directory
         self.project_path = normalise_path(project_path)
@@ -74,6 +77,7 @@ class SceptreContext(object):
         self.output_format = output_format if output_format else ""
         self.no_colour = no_colour if no_colour is True else False
         self.ignore_dependencies = ignore_dependencies if ignore_dependencies is True else False
+        self.j2_extensions = j2_extensions if j2_extensions else ()
 
     def full_config_path(self):
         """

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -18,7 +18,8 @@ class TestSceptreContext(object):
             options=sentinel.options,
             output_format=sentinel.output_format,
             no_colour=sentinel.no_colour,
-            ignore_dependencies=sentinel.ignore_dependencies
+            ignore_dependencies=sentinel.ignore_dependencies,
+            j2_extensions=sentinel.j2_extensions,
         )
 
         sentinel.project_path = "project_path/to/sceptre"
@@ -32,7 +33,8 @@ class TestSceptreContext(object):
             options=sentinel.options,
             output_format=sentinel.output_format,
             no_colour=sentinel.no_colour,
-            ignore_dependencies=sentinel.ignore_dependencies
+            ignore_dependencies=sentinel.ignore_dependencies,
+            j2_extensions=sentinel.j2_extensions,
         )
 
         full_config_path = path.join("project_path", self.config_path)
@@ -46,7 +48,8 @@ class TestSceptreContext(object):
             options=sentinel.options,
             output_format=sentinel.output_format,
             no_colour=sentinel.no_colour,
-            ignore_dependencies=sentinel.ignore_dependencies
+            ignore_dependencies=sentinel.ignore_dependencies,
+            j2_extensions=sentinel.j2_extensions,
         )
         full_command_path = path.join("project_path",
                                       self.config_path,
@@ -62,7 +65,8 @@ class TestSceptreContext(object):
             options=sentinel.options,
             output_format=sentinel.output_format,
             no_colour=sentinel.no_colour,
-            ignore_dependencies=sentinel.ignore_dependencies
+            ignore_dependencies=sentinel.ignore_dependencies,
+            j2_extensions=sentinel.j2_extensions,
         )
         full_templates_path = path.join("project_path", self.templates_path)
         assert context.full_templates_path() == full_templates_path

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -19,7 +19,7 @@ class TestSceptreContext(object):
             output_format=sentinel.output_format,
             no_colour=sentinel.no_colour,
             ignore_dependencies=sentinel.ignore_dependencies,
-            j2_extensions=sentinel.j2_extensions,
+            j2_extensions=sentinel.j2_extensions
         )
 
         sentinel.project_path = "project_path/to/sceptre"
@@ -34,7 +34,7 @@ class TestSceptreContext(object):
             output_format=sentinel.output_format,
             no_colour=sentinel.no_colour,
             ignore_dependencies=sentinel.ignore_dependencies,
-            j2_extensions=sentinel.j2_extensions,
+            j2_extensions=sentinel.j2_extensions
         )
 
         full_config_path = path.join("project_path", self.config_path)
@@ -49,7 +49,7 @@ class TestSceptreContext(object):
             output_format=sentinel.output_format,
             no_colour=sentinel.no_colour,
             ignore_dependencies=sentinel.ignore_dependencies,
-            j2_extensions=sentinel.j2_extensions,
+            j2_extensions=sentinel.j2_extensions
         )
         full_command_path = path.join("project_path",
                                       self.config_path,
@@ -66,7 +66,7 @@ class TestSceptreContext(object):
             output_format=sentinel.output_format,
             no_colour=sentinel.no_colour,
             ignore_dependencies=sentinel.ignore_dependencies,
-            j2_extensions=sentinel.j2_extensions,
+            j2_extensions=sentinel.j2_extensions
         )
         full_templates_path = path.join("project_path", self.templates_path)
         assert context.full_templates_path() == full_templates_path


### PR DESCRIPTION
Load [jinja2 extensions](https://jinja.palletsprojects.com/en/2.11.x/extensions/). From the jinja2 documentation

> Jinja supports extensions that can add extra filters, tests, globals or even extend the parser. The main motivation of extensions is to move often used code into a reusable class like adding support for internationalization.

These can be either extensions that come with jinja or custom extensions.

Example Usage:

`sceptre --j2_extension jinja2.ext.i18n --j2_extension  jinja2.ext.loopcontrols generate stack.yaml` 

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
