### PR TITLE
OPS-2361 Add command diff

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -5,3 +5,4 @@ Jinja2>=2.8,<3
 networkx==2.1
 PyYaml>=5.1,<6.0
 typing>=3.7,<3.8
+deepdiff==5.5.0

--- a/sceptre/cli/__init__.py
+++ b/sceptre/cli/__init__.py
@@ -21,6 +21,7 @@ from sceptre.cli.update import update_command
 from sceptre.cli.delete import delete_command
 from sceptre.cli.launch import launch_command
 from sceptre.cli.execute import execute_command
+from sceptre.cli.diff import diff_command
 from sceptre.cli.describe import describe_group
 from sceptre.cli.list import list_group
 from sceptre.cli.policy import set_policy_command
@@ -125,3 +126,4 @@ cli.add_command(set_policy_command)
 cli.add_command(status_command)
 cli.add_command(list_group)
 cli.add_command(describe_group)
+cli.add_command(diff_command)

--- a/sceptre/cli/diff.py
+++ b/sceptre/cli/diff.py
@@ -1,0 +1,38 @@
+import click
+
+from sceptre.context import SceptreContext
+from sceptre.cli.helpers import catch_exceptions, write
+from sceptre.config.reader import ConfigReader
+
+@click.command(name="diff", short_help="Show diffs.")
+@click.argument("path")
+@click.pass_context
+@catch_exceptions
+def diff_command(ctx, path):
+    """
+    Emit the stack name.
+
+    :param path: The path to launch. Can be a Stack or StackGroup.
+    :type path: str
+    """
+    context = SceptreContext(
+        command_path=path,
+        project_path=ctx.obj.get("project_path"),
+        user_variables=ctx.obj.get("user_variables"),
+        options=ctx.obj.get("options"),
+        ignore_dependencies=ctx.obj.get("ignore_dependencies")
+    )
+
+    stacks, _ = ConfigReader(context).construct_stacks()
+
+    for stack in list(stacks):
+        diffs = stack.diff()
+        if diffs:
+            message = "\
+Differences between running stack {} and \
+generated template:\n\
+{}".format(stack.external_name, diffs)
+        else:
+            message = "No diffs"
+
+        write(message, context.output_format)

--- a/sceptre/cli/diff.py
+++ b/sceptre/cli/diff.py
@@ -4,13 +4,13 @@ from sceptre.context import SceptreContext
 from sceptre.cli.helpers import catch_exceptions, write
 from sceptre.config.reader import ConfigReader
 
-@click.command(name="diff", short_help="Show diffs.")
+@click.command(name="diff", short_help="Show diffs with running stack.")
 @click.argument("path")
 @click.pass_context
 @catch_exceptions
 def diff_command(ctx, path):
     """
-    Emit the stack name.
+    Show diffs between the running and generated stack.
 
     :param path: The path to launch. Can be a Stack or StackGroup.
     :type path: str
@@ -26,12 +26,12 @@ def diff_command(ctx, path):
     stacks, _ = ConfigReader(context).construct_stacks()
 
     for stack in list(stacks):
-        diffs = stack.diff()
-        if diffs:
+        diff = stack.diff()
+        if diff:
             message = "\
 Differences between running stack {} and \
 generated template:\n\
-{}".format(stack.external_name, diffs)
+{}".format(stack.external_name, diff)
         else:
             message = "No diffs"
 


### PR DESCRIPTION
This implements a command diff that diffs a running stack's template via 
the GetTemplate API and the template generated by the stack.
    
The diff method is implemented in the Stack class in order to have
access to the stack's external_name.
    
Unfortunately, the Stack class does not have access to the Plan, making
it awkward to re-use the recently-implemented fetch_remote_template
command.
