### PR TITLE
OPS-2652 Add some missing unit tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ exclude_lines = [
   "if TYPE_CHECKING:",
 ]
 ignore_errors = true
-fail_under = 85.0
+fail_under = 90.0
 show_missing = true
 
 [tool.pytest.ini_options]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -466,6 +466,33 @@ class TestCli(object):
         assert result.exit_code == 0
         assert result.output == "export SCEPTRE_Key='Value'\n"
 
+    def test_fetch_remote_template(self):
+        self.mock_stack_actions.fetch_remote_template.return_value = '---\nfoo: bar'
+        result = self.runner.invoke(
+            cli, ["fetch-remote-template", "dev/vpc.yaml"]
+        )
+        assert result.exit_code == 0
+        assert result.output == '---\nfoo: bar\n'
+
+    def test_stack_name(self):
+        self.mock_stack_actions.stack_name.return_value = "mock-stack"
+        result = self.runner.invoke(
+            cli, ["stack-name", "dev/vpc.yaml"]
+        )
+        assert result.exit_code == 0
+        assert result.output == "mock-stack\n"
+
+    def test_diff(self):
+        self.mock_stack_actions.diff.return_value = [
+            "mock-stack",
+            '---\nfoo: bar'
+        ]
+        result = self.runner.invoke(
+            cli, ["diff", "dev/vpc.yaml"]
+        )
+        assert result.exit_code == 0
+        assert result.output == 'mock-stack: ---\nfoo: bar\n'
+
     def test_status_with_group(self):
         self.mock_stack_actions.get_status.return_value = {
             "stack": "status"


### PR DESCRIPTION
Recent changes saw code coverage drop from 90% to 89.66%. This appears
to result from forgetting to add unit tests in tests/test_cli.py after
adding recent CLI commands (fetch-remote-template, stack-name and diff).

This adds missing tests there to get code coverage back up over 90%.
