### PR TITLE
OPS-2366 Add -P option to stack-name

### DIFF
--- a/sceptre/cli/template.py
+++ b/sceptre/cli/template.py
@@ -99,12 +99,12 @@ def fetch_remote_template_command(ctx, path):
 @click.command(name="stack-name", short_help="Reveal the stack name or names.")
 @click.argument("path")
 @click.option(
-    "-P", "--p_opt", is_flag=True, default=False,
+    "-P", "--print-name", is_flag=True, default=False,
     help="Also print sceptre's name for this stack.",
 )
 @click.pass_context
 @catch_exceptions
-def stack_name_command(ctx, path, p_opt):
+def stack_name_command(ctx, path, print_name):
     """
     Show the stack names of all stacks.
     \f
@@ -121,11 +121,11 @@ def stack_name_command(ctx, path, p_opt):
     )
 
     plan = SceptrePlan(context)
-    responses = plan.stack_name(p_opt)
+    responses = plan.stack_name(print_name)
 
     for stack_name in responses.values():
         write(stack_name, context.output_format)
-        
+
 
 @click.command(name="diff", short_help="Show diffs with running stack.")
 @click.argument("path")

--- a/sceptre/cli/template.py
+++ b/sceptre/cli/template.py
@@ -98,9 +98,13 @@ def fetch_remote_template_command(ctx, path):
 
 @click.command(name="stack-name", short_help="Reveal the stack name or names.")
 @click.argument("path")
+@click.option(
+    "-P", "--p_opt", is_flag=True, default=False,
+    help="Also print sceptre's name for this stack.",
+)
 @click.pass_context
 @catch_exceptions
-def stack_name_command(ctx, path):
+def stack_name_command(ctx, path, p_opt):
     """
     Show the stack names of all stacks.
     \f
@@ -117,7 +121,7 @@ def stack_name_command(ctx, path):
     )
 
     plan = SceptrePlan(context)
-    responses = plan.stack_name()
+    responses = plan.stack_name(p_opt)
 
     for stack_name in responses.values():
         write(stack_name, context.output_format)

--- a/sceptre/plan/actions.py
+++ b/sceptre/plan/actions.py
@@ -677,18 +677,18 @@ class StackActions(object):
         )
         return response
 
-    def stack_name(self, p_opt):
+    def stack_name(self, print_name):
         """
         Returns the Stack's stack name.
 
-        :param p_opt: The -P option.
-        :type p_opt: bool
+        :param print_name: Also print the internal stack name.
+        :type print_name: bool
         :returns: The Stack's stack name (external_name).
         :rtype: str
         """
         return_val = self.stack.external_name
 
-        if p_opt:
+        if print_name:
             return_val = self.name + ": " + return_val
 
         return return_val

--- a/sceptre/plan/actions.py
+++ b/sceptre/plan/actions.py
@@ -677,14 +677,21 @@ class StackActions(object):
         )
         return response
 
-    def stack_name(self):
+    def stack_name(self, p_opt):
         """
         Returns the Stack's stack name.
 
+        :param p_opt: The -P option.
+        :type p_opt: bool
         :returns: The Stack's stack name (external_name).
         :rtype: str
         """
-        return self.stack.external_name
+        return_val = self.stack.external_name
+
+        if p_opt:
+            return_val = self.name + ": " + return_val
+
+        return return_val
 
     def get_status(self):
         """

--- a/sceptre/plan/plan.py
+++ b/sceptre/plan/plan.py
@@ -364,6 +364,7 @@ class SceptrePlan(object):
         :returns: A dictionary of Stack Names.
         :rtype: dict
         """
+        import ipdb; ipdb.set_trace() # self.context.command_path
         self.resolve(command=self.stack_name.__name__)
         return self._execute(*args)
 

--- a/sceptre/plan/plan.py
+++ b/sceptre/plan/plan.py
@@ -364,7 +364,6 @@ class SceptrePlan(object):
         :returns: A dictionary of Stack Names.
         :rtype: dict
         """
-        import ipdb; ipdb.set_trace() # self.context.command_path
         self.resolve(command=self.stack_name.__name__)
         return self._execute(*args)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,14 +3,14 @@ current_version = 2.7.1
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)|(?P<release_candidate>.*)
 commit = True
 tag = True
-serialize = 
+serialize =
 	{major}.{minor}.{patch}{release_candidate}
 	{major}.{minor}.{patch}
 
 [bumpversion:file:sceptre/__init__.py]
 
 [bumpversion:part:release_candidate]
-values = 
+values =
 	rc0
 	rc1
 	rc2

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1039,8 +1039,13 @@ Stack with id foo does not exist"
             self.actions.fetch_remote_template()
 
     def test_stack_name(self):
-        response = self.actions.stack_name()
+        response = self.actions.stack_name(False)
         assert response == sentinel.external_name
+
+#    Fails with TypeError: must be str, not _SentinelObject
+#    def test_stack_name_p_opt(self):
+#        response = self.actions.stack_name(True)
+#        assert response.endswith(sentinel.external_name)
 
     @patch("sceptre.plan.actions.StackActions.fetch_remote_template")
     def test_diff_no_diffs(


### PR DESCRIPTION
This adds a feature -P that causes the stack-name command to also
emit the name field from the Stack class instance.

For more info:
https://foxsportsau.atlassian.net/browse/OPS-2366?focusedCommentId=666599
