### PR TITLE
Add initial stack drift command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ exclude_lines = [
   "if TYPE_CHECKING:",
 ]
 ignore_errors = true
-fail_under = 89.0
+fail_under = 87.0
 show_missing = true
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ exclude_lines = [
   "if TYPE_CHECKING:",
 ]
 ignore_errors = true
-fail_under = 87.0
+fail_under = 90.0
 show_missing = true
 
 [tool.pytest.ini_options]

--- a/sceptre/cli/__init__.py
+++ b/sceptre/cli/__init__.py
@@ -28,8 +28,9 @@ from sceptre.cli.list import list_group
 from sceptre.cli.policy import set_policy_command
 from sceptre.cli.status import status_command
 from sceptre.cli.template import (validate_command, generate_command,
-                                  stack_name_command, fetch_remote_template_command,
-                                  diff_command, estimate_cost_command)
+                                  estimate_cost_command, stack_name_command,
+                                  fetch_remote_template_command, diff_command,
+                                  detect_stack_drift_command)
 from sceptre.cli.helpers import setup_logging, catch_exceptions
 
 
@@ -143,10 +144,11 @@ cli.add_command(execute_command)
 cli.add_command(validate_command)
 cli.add_command(estimate_cost_command)
 cli.add_command(generate_command)
-cli.add_command(fetch_remote_template_command)
-cli.add_command(stack_name_command)
-cli.add_command(diff_command)
 cli.add_command(set_policy_command)
 cli.add_command(status_command)
 cli.add_command(list_group)
 cli.add_command(describe_group)
+cli.add_command(stack_name_command)
+cli.add_command(fetch_remote_template_command)
+cli.add_command(diff_command)
+cli.add_command(detect_stack_drift_command)

--- a/sceptre/cli/__init__.py
+++ b/sceptre/cli/__init__.py
@@ -28,8 +28,9 @@ from sceptre.cli.list import list_group
 from sceptre.cli.policy import set_policy_command
 from sceptre.cli.status import status_command
 from sceptre.cli.template import (validate_command, generate_command,
-                                  estimate_cost_command, stack_name_command,
-                                  fetch_remote_template_command, diff_command,
+                                  estimate_cost_command,
+                                  fetch_remote_template_command,
+                                  stack_name_command, diff_command,
                                   detect_stack_drift_command)
 from sceptre.cli.helpers import setup_logging, catch_exceptions
 
@@ -148,7 +149,7 @@ cli.add_command(set_policy_command)
 cli.add_command(status_command)
 cli.add_command(list_group)
 cli.add_command(describe_group)
-cli.add_command(stack_name_command)
 cli.add_command(fetch_remote_template_command)
+cli.add_command(stack_name_command)
 cli.add_command(diff_command)
 cli.add_command(detect_stack_drift_command)

--- a/sceptre/plan/actions.py
+++ b/sceptre/plan/actions.py
@@ -662,10 +662,21 @@ class StackActions(object):
         elapsed = 0
 
         def print_status():
-            status_reason = response["DetectionStatusReason"]
-            self.logger.info("%s - StackDriftDetectionId - %s", self.stack.name, detect_id)
-            self.logger.info("%s - DetectionStatus - %s", self.stack.name, status)
-            self.logger.info("%s - DetectionStatusReason - %s", self.stack.name, status_reason)
+            keys = [
+                "StackDriftDetectionId",
+                "DetectionStatus",
+                "DetectionStatusReason",
+                "StackDriftStatus"
+            ]
+
+            for key in keys:
+                if key in response:
+                    status = response[key]
+                    self.logger.debug(
+                        "%s - %s - %s",
+                        self.stack.name,
+                        key, status
+                    )
 
         while True:
             if elapsed >= timeout:
@@ -675,9 +686,9 @@ class StackActions(object):
             response = self._describe_stack_drift_detection_status(detect_id)
 
             status = response["DetectionStatus"]
+            print_status()
 
             if status == "DETECTION_IN_PROGRESS":
-                print_status()
                 time.sleep(10)
                 elapsed += 10
             else:

--- a/sceptre/plan/actions.py
+++ b/sceptre/plan/actions.py
@@ -661,23 +661,6 @@ class StackActions(object):
         timeout = 300
         elapsed = 0
 
-        def print_status():
-            keys = [
-                "StackDriftDetectionId",
-                "DetectionStatus",
-                "DetectionStatusReason",
-                "StackDriftStatus"
-            ]
-
-            for key in keys:
-                if key in response:
-                    status = response[key]
-                    self.logger.debug(
-                        "%s - %s - %s",
-                        self.stack.name,
-                        key, status
-                    )
-
         while True:
             if elapsed >= timeout:
                 return "TIMED_OUT"
@@ -686,13 +669,30 @@ class StackActions(object):
             response = self._describe_stack_drift_detection_status(detect_id)
 
             status = response["DetectionStatus"]
-            print_status()
+            self._print_status(response)
 
             if status == "DETECTION_IN_PROGRESS":
                 time.sleep(10)
                 elapsed += 10
             else:
                 return status
+
+    def _print_status(self, response):
+        keys = [
+            "StackDriftDetectionId",
+            "DetectionStatus",
+            "DetectionStatusReason",
+            "StackDriftStatus"
+        ]
+
+        for key in keys:
+            if key in response:
+                status = response[key]
+                self.logger.debug(
+                    "%s - %s - %s",
+                    self.stack.name,
+                    key, status
+                )
 
     def _detect_stack_drift(self):
         """

--- a/sceptre/plan/actions.py
+++ b/sceptre/plan/actions.py
@@ -627,7 +627,6 @@ class StackActions(object):
 
         return [self.stack.external_name, response]
 
-    @add_stack_hooks
     def detect_stack_drift(self):
         """
         Detects stack drift for a running stack.

--- a/sceptre/plan/actions.py
+++ b/sceptre/plan/actions.py
@@ -633,7 +633,7 @@ class StackActions(object):
         Detects stack drift for a running stack.
 
         :returns: The stack drift.
-        :rtype: List[str]
+        :rtype: Tuple[str, Union[str, dict]]
         """
         response = self._detect_stack_drift()
 
@@ -642,9 +642,9 @@ class StackActions(object):
 
         if status == "DETECTION_COMPLETE":
             response = self._describe_stack_resource_drifts()
-            return_value = [self.stack.external_name, response]
+            return_value = (self.stack.external_name, response)
         else:
-            return_value = [self.stack.external_name, status]
+            return_value = (self.stack.external_name, status)
 
         return return_value
 
@@ -669,7 +669,7 @@ class StackActions(object):
             response = self._describe_stack_drift_detection_status(detect_id)
 
             status = response["DetectionStatus"]
-            self._print_status(response)
+            self._print_drift_status(response)
 
             if status == "DETECTION_IN_PROGRESS":
                 time.sleep(10)
@@ -677,7 +677,11 @@ class StackActions(object):
             else:
                 return status
 
-    def _print_status(self, response):
+    def _print_drift_status(self, response):
+        """
+        Print the drift status while waiting for
+        drift detection to complete.
+        """
         keys = [
             "StackDriftDetectionId",
             "DetectionStatus",
@@ -687,11 +691,10 @@ class StackActions(object):
 
         for key in keys:
             if key in response:
-                status = response[key]
                 self.logger.debug(
                     "%s - %s - %s",
                     self.stack.name,
-                    key, status
+                    key, response[key]
                 )
 
     def _detect_stack_drift(self):

--- a/sceptre/plan/plan.py
+++ b/sceptre/plan/plan.py
@@ -351,18 +351,18 @@ class SceptrePlan(object):
         """
         Returns a generated Template for a given Stack
 
-        :returns: A dictionary of Stacks and their template body.
-        :rtype: dict
+        :returns: A list of Stacks and their template body.
+        :rtype: List[str]
         """
         self.resolve(command=self.fetch_remote_template.__name__)
         return self._execute(*args)
 
     def stack_name(self, *args):
         """
-        Returns the Stack name for a given Stack
+        Returns the Stack name for a running stack.
 
-        :returns: A dictionary of Stack Names.
-        :rtype: dict
+        :returns: A list of Stack Names.
+        :rtype: List[str]
         """
         self.resolve(command=self.stack_name.__name__)
         return self._execute(*args)
@@ -371,10 +371,20 @@ class SceptrePlan(object):
         """
         Show diffs between the running and generated stack.
 
-        :returns: A dictionary of Stacks and diffs against running stack.
-        :rtype: dict
+        :returns: A list of Stacks and diffs against running stacks.
+        :rtype: List[str]
         """
         self.resolve(command=self.diff.__name__)
+        return self._execute(*args)
+
+    def detect_stack_drift(self, *args):
+        """
+        Detects stack drift for a running stack.
+
+        :returns: A list of detected drift against running stacks.
+        :rtype: List[str]
+        """
+        self.resolve(command=self.detect_stack_drift.__name__)
         return self._execute(*args)
 
     def _valid_stack_paths(self):

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1106,3 +1106,53 @@ Stack with id foo does not exist"
 
         with pytest.raises(ClientError):
             self.actions.diff()
+
+    @patch("sceptre.plan.actions.StackActions._describe_stack_resource_drifts")
+    @patch("sceptre.plan.actions.StackActions._describe_stack_drift_detection_status")
+    @patch("sceptre.plan.actions.StackActions._detect_stack_drift")
+    def test_detect_stack_drift(
+        self,
+        mock_detect_stack_drift,
+        mock_describe_stack_drift_detection_status,
+        mock_describe_stack_resource_drifts
+    ):
+        mock_detect_stack_drift.return_value = {
+            "StackDriftDetectionId": "3fb76910-f660-11eb-80ac-0246f7a6da62"
+        }
+        mock_describe_stack_drift_detection_status.side_effect = [
+            {
+                "StackId": "fake-stack-id",
+                "StackDriftDetectionId": "3fb76910-f660-11eb-80ac-0246f7a6da62",
+                "DetectionStatus": "DETECTION_IN_PROGRESS",
+                "DetectionStatusReason": "User Initiated"
+            },
+            {
+                "StackId": "fake-stack-id",
+                "StackDriftDetectionId": "3fb76910-f660-11eb-80ac-0246f7a6da62",
+                "StackDriftStatus": "IN_SYNC",
+                "DetectionStatus": "DETECTION_COMPLETE",
+                "DriftedStackResourceCount": 0
+            }
+        ]
+
+        expected_drifts = {
+            "StackResourceDrifts": [
+                {
+                    "StackId": "fake-stack-id",
+                    "LogicalResourceId": "VPC",
+                    "PhysicalResourceId": "vpc-028c655dea7c65227",
+                    "ResourceType": "AWS::EC2::VPC",
+                    "ExpectedProperties": '{"foo":"bar"}',
+                    "ActualProperties": '{"foo":"bar"}',
+                    "PropertyDifferences": [],
+                    "StackResourceDriftStatus": "IN_SYNC"
+                }
+            ]
+        }
+
+        mock_describe_stack_resource_drifts.return_value = expected_drifts
+        expected_response = [sentinel.external_name, expected_drifts]
+
+        response = self.actions.detect_stack_drift()
+
+        assert response == expected_response

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -861,3 +861,41 @@ class TestCli(object):
         encoder = CustomJsonEncoder()
         response = encoder.encode(datetime.datetime(2016, 5, 3))
         assert response == '"2016-05-03 00:00:00"'
+
+    def test_fetch_remote_template(self):
+        self.mock_stack_actions.fetch_remote_template.return_value = '---\nfoo: bar'
+        result = self.runner.invoke(
+            cli, ["fetch-remote-template", "dev/vpc.yaml"]
+        )
+        assert result.exit_code == 0
+        assert result.output == '---\nfoo: bar\n'
+
+    def test_stack_name(self):
+        self.mock_stack_actions.stack_name.return_value = "mock-stack"
+        result = self.runner.invoke(
+            cli, ["stack-name", "dev/vpc.yaml"]
+        )
+        assert result.exit_code == 0
+        assert result.output == "mock-stack\n"
+
+    def test_diff(self):
+        self.mock_stack_actions.diff.return_value = [
+            "mock-stack",
+            '---\nfoo: bar'
+        ]
+        result = self.runner.invoke(
+            cli, ["diff", "dev/vpc.yaml"]
+        )
+        assert result.exit_code == 0
+        assert result.output == 'mock-stack: ---\nfoo: bar\n'
+
+    def test_detect_stack_drift(self):
+        self.mock_stack_actions.detect_stack_drift.return_value = [
+            "mock-stack", {"some": "json"}
+        ]
+        result = self.runner.invoke(
+            cli, ["detect-stack-drift", "dev/vpc.yaml"]
+        )
+        assert result.exit_code == 0
+        assert result.output == '{\n  "mock-stack": {\n    "some": "json"\n  }\n}\n'                                                        
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -897,5 +897,4 @@ class TestCli(object):
             cli, ["detect-stack-drift", "dev/vpc.yaml"]
         )
         assert result.exit_code == 0
-        assert result.output == '{\n  "mock-stack": {\n    "some": "json"\n  }\n}\n'                                                        
-
+        assert result.output == '{\n  "mock-stack": {\n    "some": "json"\n  }\n}\n'


### PR DESCRIPTION
Add a `detect-stack-drift` command and tests.

The `detect-stack-drift` command calls the `detect_stack_drift` Boto3 call, takes the Detector Id returned, then waits for `describe_stack_drift_detection_status(StackDriftDetectionId=detector_id)` to complete, and then finally returns `describe_stack_resource_drifts` as a JSON document.

The output is formatted such that it can be passed directly into a tool like `jq`. 

If `--debug` is passed, sceptre also will provide feedback on the detection progress.