### PR TITLE
Bump version: 2.11.0 → 2.12.0

### DIFF
--- a/sceptre/__init__.py
+++ b/sceptre/__init__.py
@@ -6,7 +6,7 @@ import warnings
 
 __author__ = 'Cloudreach'
 __email__ = 'sceptre@cloudreach.com'
-__version__ = '2.11.0'
+__version__ = '2.12.0'
 
 
 # Set up logging to ``/dev/null`` like a library is supposed to.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.11.0
+current_version = 2.12.0
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)|(?P<release_candidate>.*)
 commit = True
 tag = True


### PR DESCRIPTION
Bumping our Sceptre version after merging upstream master => develop.