### PR TITLE
Refactor further to avoid merge conflicts

### DIFF
--- a/sceptre/cli/__init__.py
+++ b/sceptre/cli/__init__.py
@@ -25,9 +25,9 @@ from sceptre.cli.list import list_group
 from sceptre.cli.policy import set_policy_command
 from sceptre.cli.status import status_command
 from sceptre.cli.template import (validate_command, generate_command,
-                                  estimate_cost_command,
-                                  stack_name_command,
-                                  detect_stack_drift_command)
+                                  estimate_cost_command)
+from sceptre.cli.custom import (stack_name_command,
+                                detect_stack_drift_command)
 from sceptre.cli.helpers import catch_exceptions, setup_vars
 
 

--- a/sceptre/cli/custom.py
+++ b/sceptre/cli/custom.py
@@ -1,0 +1,72 @@
+import click
+import webbrowser
+import json
+
+from sceptre.context import SceptreContext
+from sceptre.cli.helpers import (
+    catch_exceptions,
+    write
+)
+from sceptre.plan.plan import SceptrePlan
+
+
+@click.command(name="stack-name", short_help="Reveal the stack name or names.")
+@click.argument("path")
+@click.option(
+    "-P", "--print-name", is_flag=True, default=False,
+    help="Also print sceptre's name for this stack.",
+)
+@click.pass_context
+@catch_exceptions
+def stack_name_command(ctx, path, print_name):
+    """
+    Show the stack names of all stacks.
+    \f
+
+    :param path: The path to execute the command on.
+    :type path: str
+    :param print_name: Also print the internal stack name.
+    :type print_name: bool
+    """
+    context = SceptreContext(
+        command_path=path,
+        project_path=ctx.obj.get("project_path"),
+        user_variables=ctx.obj.get("user_variables"),
+        options=ctx.obj.get("options"),
+        ignore_dependencies=ctx.obj.get("ignore_dependencies")
+    )
+
+    plan = SceptrePlan(context)
+    responses = plan.stack_name(print_name)
+
+    for response in responses.values():
+        write(response, context.output_format)
+
+
+@click.command(name="detect-stack-drift", short_help="Detects stack drift on running stacks.")
+@click.argument("path")
+@click.pass_context
+@catch_exceptions
+def detect_stack_drift_command(ctx, path):
+    """
+    Detect stack drift on running stacks.
+    \f
+
+    :param path: The path to execute the command on.
+    :type path: str
+    """
+    context = SceptreContext(
+        command_path=path,
+        project_path=ctx.obj.get("project_path"),
+        user_variables=ctx.obj.get("user_variables"),
+        options=ctx.obj.get("options"),
+        ignore_dependencies=ctx.obj.get("ignore_dependencies")
+    )
+
+    plan = SceptrePlan(context)
+    responses = plan.detect_stack_drift()
+    output = "\n".join([
+        json.dumps({stack_name: response}, sort_keys=True, indent=2, default=str)
+        for stack_name, response in responses.values()
+    ])
+    write(output, context.output_format)

--- a/sceptre/cli/custom.py
+++ b/sceptre/cli/custom.py
@@ -1,5 +1,4 @@
 import click
-import webbrowser
 import json
 
 from sceptre.context import SceptreContext

--- a/sceptre/cli/template.py
+++ b/sceptre/cli/template.py
@@ -1,6 +1,5 @@
 import click
 import webbrowser
-import json
 
 from sceptre.context import SceptreContext
 from sceptre.cli.helpers import (
@@ -101,65 +100,3 @@ def estimate_cost_command(ctx, path):
             response = response["Url"]
             webbrowser.open(response, new=2)
         write(response + "\n", 'text')
-
-
-@click.command(name="stack-name", short_help="Reveal the stack name or names.")
-@click.argument("path")
-@click.option(
-    "-P", "--print-name", is_flag=True, default=False,
-    help="Also print sceptre's name for this stack.",
-)
-@click.pass_context
-@catch_exceptions
-def stack_name_command(ctx, path, print_name):
-    """
-    Show the stack names of all stacks.
-    \f
-
-    :param path: The path to execute the command on.
-    :type path: str
-    :param print_name: Also print the internal stack name.
-    :type print_name: bool
-    """
-    context = SceptreContext(
-        command_path=path,
-        project_path=ctx.obj.get("project_path"),
-        user_variables=ctx.obj.get("user_variables"),
-        options=ctx.obj.get("options"),
-        ignore_dependencies=ctx.obj.get("ignore_dependencies")
-    )
-
-    plan = SceptrePlan(context)
-    responses = plan.stack_name(print_name)
-
-    for response in responses.values():
-        write(response, context.output_format)
-
-
-@click.command(name="detect-stack-drift", short_help="Detects stack drift on running stacks.")
-@click.argument("path")
-@click.pass_context
-@catch_exceptions
-def detect_stack_drift_command(ctx, path):
-    """
-    Detect stack drift on running stacks.
-    \f
-
-    :param path: The path to execute the command on.
-    :type path: str
-    """
-    context = SceptreContext(
-        command_path=path,
-        project_path=ctx.obj.get("project_path"),
-        user_variables=ctx.obj.get("user_variables"),
-        options=ctx.obj.get("options"),
-        ignore_dependencies=ctx.obj.get("ignore_dependencies")
-    )
-
-    plan = SceptrePlan(context)
-    responses = plan.detect_stack_drift()
-    output = "\n".join([
-        json.dumps({stack_name: response}, sort_keys=True, indent=2, default=str)
-        for stack_name, response in responses.values()
-    ])
-    write(output, context.output_format)

--- a/sceptre/plan/actions.py
+++ b/sceptre/plan/actions.py
@@ -15,7 +15,6 @@ from datetime import datetime, timedelta
 
 import botocore
 import json
-import yaml
 
 from dateutil.tz import tzutc
 
@@ -29,11 +28,12 @@ from sceptre.exceptions import UnknownStackStatusError
 from sceptre.exceptions import UnknownStackChangeSetStatusError
 from sceptre.exceptions import StackDoesNotExistError
 from sceptre.exceptions import ProtectedStackError
+from sceptre.plan.actions_custom import StackActionsCustom
 
 import urllib
 
 
-class StackActions(object):
+class StackActions(StackActionsCustom):
     """
     StackActions stores the operations a Stack can take, such as creating or
     deleting the Stack.
@@ -929,132 +929,3 @@ class StackActions(object):
             return StackChangeSetStatus.DEFUNCT
         else:  # pragma: no cover
             raise Exception("This else should not be reachable.")
-
-    @add_stack_hooks
-    def stack_name(self, print_name):
-        """
-        Returns the Stack's stack name.
-
-        :param print_name: Also print the internal stack name.
-        :type print_name: bool
-        :returns: The Stack's stack name (external_name).
-        :rtype: str
-        """
-        return_value = self.stack.external_name
-
-        if print_name:
-            return_value = self.name + ": " + return_value
-
-        return return_value
-
-    @add_stack_hooks
-    def detect_stack_drift(self):
-        """
-        Detects stack drift for a running stack.
-
-        :returns: The stack drift.
-        :rtype: Tuple[str, Union[str, dict]]
-        """
-        response = self._detect_stack_drift()
-
-        detection_id = response["StackDriftDetectionId"]
-        status = self._wait_for_drift(detection_id)
-
-        if status == "DETECTION_COMPLETE":
-            response = self._describe_stack_resource_drifts()
-            return_value = (self.stack.external_name, response)
-        else:
-            return_value = (self.stack.external_name, status)
-
-        return return_value
-
-    def _wait_for_drift(self, detection_id):
-        """
-        Waits for drift detection to complete.
-
-        :param detection_id: The drift detection ID.
-        :type detection_id: str
-
-        :returns: The drift status.
-        :rtype: str
-        """
-        timeout = 300
-        elapsed = 0
-
-        while True:
-            if elapsed >= timeout:
-                return "TIMED_OUT"
-
-            self.logger.debug("%s - Waiting for drift detection", self.stack.name)
-            response = self._describe_stack_drift_detection_status(detection_id)
-
-            status = response["DetectionStatus"]
-            self._print_drift_status(response)
-
-            if status == "DETECTION_IN_PROGRESS":
-                time.sleep(10)
-                elapsed += 10
-            else:
-                return status
-
-    def _print_drift_status(self, response):
-        """
-        Print the drift status while waiting for
-        drift detection to complete.
-        """
-        keys = [
-            "StackDriftDetectionId",
-            "DetectionStatus",
-            "DetectionStatusReason",
-            "StackDriftStatus"
-        ]
-
-        for key in keys:
-            if key in response:
-                self.logger.debug(
-                    "%s - %s - %s",
-                    self.stack.name,
-                    key, response[key]
-                )
-
-    def _detect_stack_drift(self):
-        """
-        Run detect_stack_drift.
-        """
-        self.logger.debug("%s - Detecting Stack Drift", self.stack.name)
-
-        return self.connection_manager.call(
-            service="cloudformation",
-            command="detect_stack_drift",
-            kwargs={
-                "StackName": self.stack.external_name
-            }
-        )
-
-    def _describe_stack_drift_detection_status(self, detection_id):
-        """
-        Run describe_stack_drift_detection_status.
-        """
-        self.logger.debug("%s - Detecting Stack Drift Detection Status", self.stack.name)
-
-        return self.connection_manager.call(
-            service="cloudformation",
-            command="describe_stack_drift_detection_status",
-            kwargs={
-                "StackDriftDetectionId": detection_id
-            }
-        )
-
-    def _describe_stack_resource_drifts(self):
-        """
-        Detects stack resource_drifts for a running stack.
-        """
-        self.logger.debug("%s - Detecting Stack Drift", self.stack.name)
-
-        return self.connection_manager.call(
-            service="cloudformation",
-            command="describe_stack_resource_drifts",
-            kwargs={
-                "StackName": self.stack.external_name
-            }
-        )

--- a/sceptre/plan/actions_custom.py
+++ b/sceptre/plan/actions_custom.py
@@ -1,0 +1,142 @@
+# -*- coding: utf-8 -*-
+
+"""
+sceptre.plan.actions_custom
+
+Custom code that is inherited in SceptrePlan.
+"""
+
+import time
+from sceptre.hooks import add_stack_hooks
+
+
+class StackActionsCustom(object):
+
+    @add_stack_hooks
+    def stack_name(self, print_name):
+        """
+        Returns the Stack's stack name.
+
+        :param print_name: Also print the internal stack name.
+        :type print_name: bool
+        :returns: The Stack's stack name (external_name).
+        :rtype: str
+        """
+        return_value = self.stack.external_name
+
+        if print_name:
+            return_value = self.name + ": " + return_value
+
+        return return_value
+
+    @add_stack_hooks
+    def detect_stack_drift(self):
+        """
+        Detects stack drift for a running stack.
+
+        :returns: The stack drift.
+        :rtype: Tuple[str, Union[str, dict]]
+        """
+        response = self._detect_stack_drift()
+
+        detection_id = response["StackDriftDetectionId"]
+        status = self._wait_for_drift(detection_id)
+
+        if status == "DETECTION_COMPLETE":
+            response = self._describe_stack_resource_drifts()
+            return_value = (self.stack.external_name, response)
+        else:
+            return_value = (self.stack.external_name, status)
+
+        return return_value
+
+    def _wait_for_drift(self, detection_id):
+        """
+        Waits for drift detection to complete.
+
+        :param detection_id: The drift detection ID.
+        :type detection_id: str
+
+        :returns: The drift status.
+        :rtype: str
+        """
+        timeout = 300
+        elapsed = 0
+
+        while True:
+            if elapsed >= timeout:
+                return "TIMED_OUT"
+
+            self.logger.debug("%s - Waiting for drift detection", self.stack.name)
+            response = self._describe_stack_drift_detection_status(detection_id)
+
+            status = response["DetectionStatus"]
+            self._print_drift_status(response)
+
+            if status == "DETECTION_IN_PROGRESS":
+                time.sleep(10)
+                elapsed += 10
+            else:
+                return status
+
+    def _print_drift_status(self, response):
+        """
+        Print the drift status while waiting for
+        drift detection to complete.
+        """
+        keys = [
+            "StackDriftDetectionId",
+            "DetectionStatus",
+            "DetectionStatusReason",
+            "StackDriftStatus"
+        ]
+
+        for key in keys:
+            if key in response:
+                self.logger.debug(
+                    "%s - %s - %s",
+                    self.stack.name,
+                    key, response[key]
+                )
+
+    def _detect_stack_drift(self):
+        """
+        Run detect_stack_drift.
+        """
+        self.logger.debug("%s - Detecting Stack Drift", self.stack.name)
+
+        return self.connection_manager.call(
+            service="cloudformation",
+            command="detect_stack_drift",
+            kwargs={
+                "StackName": self.stack.external_name
+            }
+        )
+
+    def _describe_stack_drift_detection_status(self, detection_id):
+        """
+        Run describe_stack_drift_detection_status.
+        """
+        self.logger.debug("%s - Detecting Stack Drift Detection Status", self.stack.name)
+
+        return self.connection_manager.call(
+            service="cloudformation",
+            command="describe_stack_drift_detection_status",
+            kwargs={
+                "StackDriftDetectionId": detection_id
+            }
+        )
+
+    def _describe_stack_resource_drifts(self):
+        """
+        Detects stack resource_drifts for a running stack.
+        """
+        self.logger.debug("%s - Detecting Stack Drift", self.stack.name)
+
+        return self.connection_manager.call(
+            service="cloudformation",
+            command="describe_stack_resource_drifts",
+            kwargs={
+                "StackName": self.stack.external_name
+            }
+        )

--- a/sceptre/plan/plan.py
+++ b/sceptre/plan/plan.py
@@ -13,9 +13,9 @@ from sceptre.config.graph import StackGraph
 from sceptre.config.reader import ConfigReader
 from sceptre.plan.executor import SceptrePlanExecutor
 from sceptre.helpers import sceptreise_path
+from sceptre.plan.plan_custom import SceptrePlanCustom
 
-
-class SceptrePlan(object):
+class SceptrePlan(SceptrePlanCustom):
 
     def __init__(self, context):
         """
@@ -354,23 +354,3 @@ class SceptrePlan(object):
             for f in files
             if not f.endswith(self.context.config_file)
         ]
-
-    def stack_name(self, *args):
-        """
-        Returns the Stack name for a running stack.
-
-        :returns: A list of Stack Names.
-        :rtype: List[str]
-        """
-        self.resolve(command=self.stack_name.__name__)
-        return self._execute(*args)
-
-    def detect_stack_drift(self, *args):
-        """
-        Detects stack drift for a running stack.
-
-        :returns: A list of detected drift against running stacks.
-        :rtype: List[str]
-        """
-        self.resolve(command=self.detect_stack_drift.__name__)
-        return self._execute(*args)

--- a/sceptre/plan/plan.py
+++ b/sceptre/plan/plan.py
@@ -15,6 +15,7 @@ from sceptre.plan.executor import SceptrePlanExecutor
 from sceptre.helpers import sceptreise_path
 from sceptre.plan.plan_custom import SceptrePlanCustom
 
+
 class SceptrePlan(SceptrePlanCustom):
 
     def __init__(self, context):

--- a/sceptre/plan/plan_custom.py
+++ b/sceptre/plan/plan_custom.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+"""
+sceptre.plan.plan_custom
+
+Custom code that is inherited in SceptrePlan.
+"""
+
+class SceptrePlanCustom():
+
+    def stack_name(self, *args):
+        """
+        Returns the Stack name for a running stack.
+
+        :returns: A list of Stack Names.
+        :rtype: List[str]
+        """
+        self.resolve(command=self.stack_name.__name__)
+        return self._execute(*args)
+
+    def detect_stack_drift(self, *args):
+        """
+        Detects stack drift for a running stack.
+
+        :returns: A list of detected drift against running stacks.
+        :rtype: List[str]
+        """
+        self.resolve(command=self.detect_stack_drift.__name__)
+        return self._execute(*args)

--- a/sceptre/plan/plan_custom.py
+++ b/sceptre/plan/plan_custom.py
@@ -6,6 +6,7 @@ sceptre.plan.plan_custom
 Custom code that is inherited in SceptrePlan.
 """
 
+
 class SceptrePlanCustom():
 
     def stack_name(self, *args):

--- a/tests/test_actions_custom.py
+++ b/tests/test_actions_custom.py
@@ -1,23 +1,10 @@
 # -*- coding: utf-8 -*-
 
-import pytest
-from mock import patch, sentinel, Mock, call
-
-import datetime
-from dateutil.tz import tzutc
-
-from botocore.exceptions import ClientError
+from mock import patch, sentinel
 
 from sceptre.stack import Stack
 from sceptre.plan.actions import StackActions
 from sceptre.template import Template
-from sceptre.stack_status import StackStatus
-from sceptre.stack_status import StackChangeSetStatus
-from sceptre.exceptions import CannotUpdateFailedStackError
-from sceptre.exceptions import UnknownStackStatusError
-from sceptre.exceptions import UnknownStackChangeSetStatusError
-from sceptre.exceptions import StackDoesNotExistError
-from sceptre.exceptions import ProtectedStackError
 
 
 class TestStackActions(object):

--- a/tests/test_actions_custom.py
+++ b/tests/test_actions_custom.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+from mock import patch, sentinel, Mock, call
+
+import datetime
+from dateutil.tz import tzutc
+
+from botocore.exceptions import ClientError
+
+from sceptre.stack import Stack
+from sceptre.plan.actions import StackActions
+from sceptre.template import Template
+from sceptre.stack_status import StackStatus
+from sceptre.stack_status import StackChangeSetStatus
+from sceptre.exceptions import CannotUpdateFailedStackError
+from sceptre.exceptions import UnknownStackStatusError
+from sceptre.exceptions import UnknownStackChangeSetStatusError
+from sceptre.exceptions import StackDoesNotExistError
+from sceptre.exceptions import ProtectedStackError
+
+
+class TestStackActions(object):
+
+    def setup_method(self, test_method):
+        self.patcher_connection_manager = patch(
+            "sceptre.plan.actions.ConnectionManager"
+        )
+        self.mock_ConnectionManager = self.patcher_connection_manager.start()
+        self.stack = Stack(
+            name='prod/app/stack', project_code=sentinel.project_code,
+            template_path=sentinel.template_path, region=sentinel.region,
+            profile=sentinel.profile, parameters={"key1": "val1"}, sceptre_user_data=sentinel.sceptre_user_data,
+            hooks={}, s3_details=None, dependencies=sentinel.dependencies,
+            role_arn=sentinel.role_arn, protected=False,
+            tags={"tag1": "val1"}, external_name=sentinel.external_name,
+            notifications=[sentinel.notification],
+            on_failure=sentinel.on_failure,
+            stack_timeout=sentinel.stack_timeout
+        )
+        self.actions = StackActions(self.stack)
+        self.stack_group_config = {}
+        self.template = Template(
+            "fixtures/templates", self.stack.template_handler_config,
+            self.stack.sceptre_user_data, self.stack_group_config,
+            self.actions.connection_manager, self.stack.s3_details
+        )
+        self.stack._template = self.template
+
+    def teardown_method(self, test_method):
+        self.patcher_connection_manager.stop()
+
+    def test_stack_name(self):
+        response = self.actions.stack_name(False)
+        assert response == sentinel.external_name
+
+#    Fails with TypeError: must be str, not _SentinelObject
+#    def test_stack_name_p_opt(self):
+#        response = self.actions.stack_name(True)
+#        assert response.endswith(sentinel.external_name)
+
+    @patch("sceptre.plan.actions.StackActions._describe_stack_resource_drifts")
+    @patch("sceptre.plan.actions.StackActions._describe_stack_drift_detection_status")
+    @patch("sceptre.plan.actions.StackActions._detect_stack_drift")
+    def test_detect_stack_drift(
+        self,
+        mock_detect_stack_drift,
+        mock_describe_stack_drift_detection_status,
+        mock_describe_stack_resource_drifts
+    ):
+        mock_detect_stack_drift.return_value = {
+            "StackDriftDetectionId": "3fb76910-f660-11eb-80ac-0246f7a6da62"
+        }
+        mock_describe_stack_drift_detection_status.side_effect = [
+            {
+                "StackId": "fake-stack-id",
+                "StackDriftDetectionId": "3fb76910-f660-11eb-80ac-0246f7a6da62",
+                "DetectionStatus": "DETECTION_IN_PROGRESS",
+                "DetectionStatusReason": "User Initiated"
+            },
+            {
+                "StackId": "fake-stack-id",
+                "StackDriftDetectionId": "3fb76910-f660-11eb-80ac-0246f7a6da62",
+                "StackDriftStatus": "IN_SYNC",
+                "DetectionStatus": "DETECTION_COMPLETE",
+                "DriftedStackResourceCount": 0
+            }
+        ]
+
+        expected_drifts = {
+            "StackResourceDrifts": [
+                {
+                    "StackId": "fake-stack-id",
+                    "LogicalResourceId": "VPC",
+                    "PhysicalResourceId": "vpc-028c655dea7c65227",
+                    "ResourceType": "AWS::EC2::VPC",
+                    "ExpectedProperties": '{"foo":"bar"}',
+                    "ActualProperties": '{"foo":"bar"}',
+                    "PropertyDifferences": [],
+                    "StackResourceDriftStatus": "IN_SYNC"
+                }
+            ]
+        }
+
+        mock_describe_stack_resource_drifts.return_value = expected_drifts
+        expected_response = (sentinel.external_name, expected_drifts)
+
+        response = self.actions.detect_stack_drift()
+
+        assert response == expected_response

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -912,21 +912,3 @@ class TestCli(object):
         encoder = CustomJsonEncoder()
         response = encoder.encode(datetime.datetime(2016, 5, 3))
         assert response == '"2016-05-03 00:00:00"'
-
-    def test_stack_name(self):
-        self.mock_stack_actions.stack_name.return_value = "mock-stack"
-        result = self.runner.invoke(
-            cli, ["stack-name", "dev/vpc.yaml"]
-        )
-        assert result.exit_code == 0
-        assert result.output == "mock-stack\n"
-
-    def test_detect_stack_drift(self):
-        self.mock_stack_actions.detect_stack_drift.return_value = [
-            "mock-stack", {"some": "json"}
-        ]
-        result = self.runner.invoke(
-            cli, ["detect-stack-drift", "dev/vpc.yaml"]
-        )
-        assert result.exit_code == 0
-        assert result.output == '{\n  "mock-stack": {\n    "some": "json"\n  }\n}\n'

--- a/tests/test_cli_custom.py
+++ b/tests/test_cli_custom.py
@@ -1,0 +1,74 @@
+import logging
+import yaml
+import datetime
+import os
+import errno
+import json
+
+from click.testing import CliRunner
+from mock import MagicMock, patch, sentinel
+import pytest
+import click
+
+from sceptre.cli import cli
+from sceptre.config.reader import ConfigReader
+from sceptre.stack import Stack
+from sceptre.plan.actions import StackActions
+from sceptre.stack_status import StackStatus
+from sceptre.cli.helpers import setup_logging, write, ColouredFormatter
+from sceptre.cli.helpers import CustomJsonEncoder, catch_exceptions
+from botocore.exceptions import ClientError
+from sceptre.exceptions import SceptreException
+
+
+class TestCliCustom(object):
+
+    def setup_method(self, test_method):
+        self.patcher_ConfigReader = patch("sceptre.plan.plan.ConfigReader")
+        self.patcher_StackActions = patch("sceptre.plan.executor.StackActions")
+
+        self.mock_ConfigReader = self.patcher_ConfigReader.start()
+        self.mock_StackActions = self.patcher_StackActions.start()
+
+        self.mock_config_reader = MagicMock(spec=ConfigReader)
+        self.mock_stack_actions = MagicMock(spec=StackActions)
+
+        self.mock_stack = MagicMock(spec=Stack)
+
+        self.mock_stack.name = 'mock-stack'
+        self.mock_stack.region = None
+        self.mock_stack.profile = None
+        self.mock_stack.external_name = None
+        self.mock_stack.dependencies = []
+
+        self.mock_config_reader.construct_stacks.return_value = \
+            set([self.mock_stack]), set([self.mock_stack])
+
+        self.mock_stack_actions.stack = self.mock_stack
+
+        self.mock_ConfigReader.return_value = self.mock_config_reader
+        self.mock_StackActions.return_value = self.mock_stack_actions
+
+        self.runner = CliRunner()
+
+    def teardown_method(self, test_method):
+        self.patcher_ConfigReader.stop()
+        self.patcher_StackActions.stop()
+
+    def test_stack_name(self):
+        self.mock_stack_actions.stack_name.return_value = "mock-stack"
+        result = self.runner.invoke(
+            cli, ["stack-name", "dev/vpc.yaml"]
+        )
+        assert result.exit_code == 0
+        assert result.output == "mock-stack\n"
+
+    def test_detect_stack_drift(self):
+        self.mock_stack_actions.detect_stack_drift.return_value = [
+            "mock-stack", {"some": "json"}
+        ]
+        result = self.runner.invoke(
+            cli, ["detect-stack-drift", "dev/vpc.yaml"]
+        )
+        assert result.exit_code == 0
+        assert result.output == '{\n  "mock-stack": {\n    "some": "json"\n  }\n}\n'

--- a/tests/test_cli_custom.py
+++ b/tests/test_cli_custom.py
@@ -1,24 +1,10 @@
-import logging
-import yaml
-import datetime
-import os
-import errno
-import json
-
 from click.testing import CliRunner
-from mock import MagicMock, patch, sentinel
-import pytest
-import click
+from mock import MagicMock, patch
 
 from sceptre.cli import cli
 from sceptre.config.reader import ConfigReader
 from sceptre.stack import Stack
 from sceptre.plan.actions import StackActions
-from sceptre.stack_status import StackStatus
-from sceptre.cli.helpers import setup_logging, write, ColouredFormatter
-from sceptre.cli.helpers import CustomJsonEncoder, catch_exceptions
-from botocore.exceptions import ClientError
-from sceptre.exceptions import SceptreException
 
 
 class TestCliCustom(object):


### PR DESCRIPTION
This change moves custom code from sceptre.cli.template into
sceptre.cli.custom and custom unit tests to tests/test_actions_custom.py
and tests/test_cli_custom.py. Also creates classes SceptrePlanCustom and
StackActionsCustom for the same reason. These are inherited and extended
by SceptrePlan and StackActions respectively.

The intention is to avoid the risk of merge conflicts and make merge
conflicts that do occur easier to resolve.
